### PR TITLE
Fix CI package installation to use uv correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,18 @@ jobs:
         # Create fresh venv for testing
         rm -rf .test_venv
         uv venv .test_venv
-        source .test_venv/bin/activate
 
         echo "Installing elroy from wheel..."
         ls -la ./dist/
-        uv pip install ./dist/elroy-*.whl
+        uv pip install --python .test_venv/bin/python ./dist/elroy-*.whl
 
         echo "Verifying installation..."
-        which elroy
-        python -c "import elroy; print(f'Elroy {elroy.__version__} installed successfully')"
-        elroy version
+        .test_venv/bin/python -c "import elroy; print(f'Elroy {elroy.__version__} installed successfully')"
+        .test_venv/bin/elroy version
 
         echo "Running CLI tests..."
+        # Add venv bin to PATH so test_cli.sh can find elroy
+        export PATH="$(pwd)/.test_venv/bin:$PATH"
         bash scripts/test_cli.sh
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
Fix the test-install job in the release workflow that was failing with ModuleNotFoundError.

## Problem
The CI was failing with:
```
ModuleNotFoundError: No module named 'elroy'
```

Even though the Python import check passed, the `elroy` CLI command couldn't find the module.

## Root Cause
When using `uv pip install`, simply sourcing the venv doesn't make uv use it automatically. The package was being installed somewhere else, and the elroy script's shebang wasn't pointing to the correct Python interpreter.

## Solution
1. Use `uv pip install --python .test_venv/bin/python` to explicitly target the test venv
2. Call `.test_venv/bin/elroy` directly for verification
3. Add `.test_venv/bin` to PATH for the test_cli.sh script which calls `elroy` many times

## Testing
This should fix the failing release CI for v0.3.0.

🤖 Generated with Claude Code