### PR TITLE
Run tests from /tmp to avoid source directory shadowing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
       run: |
         source .venv/bin/activate
         uv pip install ./dist/elroy-*.whl
-        bash scripts/test_cli.sh
+        # Run tests from /tmp to avoid Python finding local source instead of installed package
+        cd /tmp
+        bash $GITHUB_WORKSPACE/scripts/test_cli.sh
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Fix the ModuleNotFoundError by running tests from outside the source directory.

## Root Cause
We were running tests from `/home/runner/work/elroy/elroy` - inside the elroy source directory. Python was finding the local `elroy/` source directory instead of the installed package in `site-packages`.

This is a classic Python shadowing issue where local directories take precedence over installed packages.

## Solution
```yaml
cd /tmp
bash $GITHUB_WORKSPACE/scripts/test_cli.sh
```

Run tests from `/tmp` to ensure Python imports the installed package from site-packages, not the local source.

## Testing
This should finally fix the v0.3.0 release CI!

🤖 Generated with Claude Code