### PR TITLE
Use pip instead of uv pip for package installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Test built package
       run: |
         source .venv/bin/activate
-        uv pip install ./dist/elroy-*.whl
+        pip install ./dist/elroy-*.whl
         # Run tests from /tmp to avoid Python finding local source instead of installed package
         cd /tmp
         bash $GITHUB_WORKSPACE/scripts/test_cli.sh


### PR DESCRIPTION
uv pip is not properly setting up entry points in the venv. The elroy CLI script can't find the module even though it's installed. Using standard pip should fix this.