### PR TITLE
Move source directory during tests to prevent shadowing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,13 @@ jobs:
 
     - name: Test built package
       run: |
+        # Temporarily move source to avoid Python path shadowing
+        mv elroy elroy_source_backup
         source .venv/bin/activate
         uv pip install ./dist/elroy-*.whl
         bash scripts/test_cli.sh
+        # Restore source
+        mv elroy_source_backup elroy
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Fix Python path shadowing by temporarily renaming source directory during tests.