### PR TITLE
Fix v0.3.0 package build configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,10 +137,9 @@ exclude_lines = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build.targets.wheel]
-packages = ["elroy"]
-include = ["claude-skills"]
+[tool.hatch.build.targets.wheel.force-include]
+"claude-skills" = "claude-skills"
 
-[tool.hatch.build.targets.sdist]
-include = ["claude-skills/**/*"]
+[tool.hatch.build.targets.sdist.force-include]
+"claude-skills" = "claude-skills"
 


### PR DESCRIPTION
Fixes the broken package build that was causing ModuleNotFoundError in the release CI.

## Root Cause
The hatch build configuration added in v0.3.0 used `packages = ["elroy"]` which put hatch into explicit mode but didn't properly configure the package path. This prevented auto-discovery of the elroy package directory, resulting in wheels that contained only metadata without the actual Python code.

## Solution
- Remove the explicit `packages` directive to restore hatch's default auto-discovery
- Use `force-include` to add the claude-skills directory

This restores the working behavior from v0.2.0 while maintaining claude-skills inclusion.

## Testing
- Built and tested package locally
- Verified wheel contains both elroy package and claude-skills directory
- Tested installation in fresh venv and confirmed import works correctly