### PR TITLE
Add agenda items feature

### DIFF
--- a/elroy/config/paths.py
+++ b/elroy/config/paths.py
@@ -43,3 +43,9 @@ def get_log_file_path():
     logs_dir = get_home_dir() / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     return logs_dir / "elroy.log"
+
+
+def get_agenda_dir() -> Path:
+    agenda_dir = get_home_dir() / "agenda"
+    agenda_dir.mkdir(parents=True, exist_ok=True)
+    return agenda_dir

--- a/elroy/io/completions.py
+++ b/elroy/io/completions.py
@@ -24,7 +24,9 @@ def build_completions(ctx: ElroyContext) -> list[str]:
     from ..repository.memories.queries import get_active_memories
     from ..repository.recall.queries import is_in_context
     from ..repository.reminders.queries import get_active_reminders
+    from ..repository.agenda.tools import get_today_agenda_titles
     from ..tools.tools_and_commands import (
+        ALL_ACTIVE_AGENDA_COMMANDS,
         ALL_ACTIVE_MEMORY_COMMANDS,
         ALL_ACTIVE_REMINDER_COMMANDS,
         IN_CONTEXT_MEMORY_COMMANDS,
@@ -36,6 +38,7 @@ def build_completions(ctx: ElroyContext) -> list[str]:
     context_messages = list(get_context_messages(ctx))
     memories = get_active_memories(ctx)
     reminders = get_active_reminders(ctx)
+    agenda_titles = get_today_agenda_titles()
 
     in_context_memories = sorted([m.get_name() for m in memories if is_in_context(context_messages, m)])
     non_context_memories = sorted([m.get_name() for m in memories if m.get_name() not in in_context_memories])
@@ -47,6 +50,7 @@ def build_completions(ctx: ElroyContext) -> list[str]:
             product(NON_CONTEXT_MEMORY_COMMANDS, non_context_memories),
             product(ALL_ACTIVE_MEMORY_COMMANDS, [m.get_name() for m in memories]),
             product(ALL_ACTIVE_REMINDER_COMMANDS, reminder_names),
+            product(ALL_ACTIVE_AGENDA_COMMANDS, agenda_titles),
         ),
         tmap(lambda x: f"/{x[0].__name__} {x[1]}"),
         list,

--- a/elroy/repository/agenda/file_storage.py
+++ b/elroy/repository/agenda/file_storage.py
@@ -1,0 +1,72 @@
+"""File storage helpers for agenda items."""
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..file_utils import (
+    read_file_text,
+    read_frontmatter,
+    sanitize_filename,
+    update_frontmatter_fields,
+)
+
+
+def _build_file_content(text: str, item_date: date, completed: bool = False) -> str:
+    fm = {"date": item_date.isoformat(), "completed": completed}
+    frontmatter_str = yaml.dump(fm, default_flow_style=False).strip()
+    return f"---\n{frontmatter_str}\n---\n\n{text}"
+
+
+def get_agenda_file_path(agenda_dir: Path, name: str) -> Path:
+    """Return a unique path for a new agenda item file."""
+    base = sanitize_filename(name, fallback="agenda_item")
+    candidate = agenda_dir / f"{base}.md"
+    if not candidate.exists():
+        return candidate
+    counter = 2
+    while True:
+        candidate = agenda_dir / f"{base}-{counter}.md"
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
+def write_agenda_item(agenda_dir: Path, name: str, text: str, item_date: date) -> Path:
+    """Write a new agenda item file. Returns the path."""
+    path = get_agenda_file_path(agenda_dir, name)
+    path.write_text(_build_file_content(text, item_date))
+    return path
+
+
+def mark_completed(path: Path) -> None:
+    """Set completed: true in the frontmatter of an agenda item file."""
+    update_frontmatter_fields(path, {"completed": True})
+
+
+def list_agenda_items(agenda_dir: Path, for_date: date | None = None) -> list[tuple[Path, dict[str, Any], str]]:
+    """Return list of (path, frontmatter, text) for all agenda items.
+
+    If for_date is given, only return items matching that date.
+    Items with completed=True are excluded.
+    """
+    results = []
+    for path in sorted(agenda_dir.glob("*.md")):
+        fm = read_frontmatter(path)
+        if fm.get("completed"):
+            continue
+        if for_date is not None:
+            item_date_raw = fm.get("date")
+            if item_date_raw is None:
+                continue
+            try:
+                item_date = item_date_raw if isinstance(item_date_raw, date) else date.fromisoformat(str(item_date_raw))
+            except ValueError:
+                continue
+            if item_date != for_date:
+                continue
+        text = read_file_text(path).strip()
+        results.append((path, fm, text))
+    return results

--- a/elroy/repository/agenda/tools.py
+++ b/elroy/repository/agenda/tools.py
@@ -1,0 +1,123 @@
+"""Tools for managing daily agenda items."""
+
+from datetime import date
+
+from rich.table import Table
+
+from ...config.paths import get_agenda_dir
+from ...core.constants import RecoverableToolError, tool, user_only_tool
+from ...core.ctx import ElroyContext
+from .file_storage import (
+    list_agenda_items,
+    mark_completed,
+    write_agenda_item,
+)
+
+
+@tool
+def add_agenda_item(ctx: ElroyContext, text: str, item_date: str | None = None) -> str:
+    """Add a new agenda item for a given date (defaults to today).
+
+    Args:
+        text (str): The agenda item text.
+        item_date (str | None): ISO 8601 date string (YYYY-MM-DD). Defaults to today.
+
+    Returns:
+        str: Confirmation message.
+    """
+    if item_date:
+        try:
+            target_date = date.fromisoformat(item_date)
+        except ValueError as e:
+            raise RecoverableToolError(f"Invalid date format '{item_date}'. Use YYYY-MM-DD.") from e
+    else:
+        target_date = date.today()
+
+    agenda_dir = get_agenda_dir()
+    # Use the first line of text as the file name base
+    name = text.split("\n")[0][:60]
+    path = write_agenda_item(agenda_dir, name, text, target_date)
+    return f"Agenda item added for {target_date.isoformat()}: {path.stem}"
+
+
+@tool
+def complete_agenda_item(ctx: ElroyContext, item_name: str) -> str:
+    """Mark an agenda item as completed.
+
+    Args:
+        item_name (str): The file stem (name without .md) of the agenda item, or a substring of it.
+
+    Returns:
+        str: Confirmation message.
+    """
+    agenda_dir = get_agenda_dir()
+    matches = [p for p in agenda_dir.glob("*.md") if item_name.lower() in p.stem.lower()]
+    if not matches:
+        raise RecoverableToolError(f"No agenda item found matching '{item_name}'.")
+    if len(matches) > 1:
+        names = ", ".join(p.stem for p in matches)
+        raise RecoverableToolError(f"Multiple agenda items match '{item_name}': {names}. Be more specific.")
+    mark_completed(matches[0])
+    return f"Agenda item '{matches[0].stem}' marked as completed."
+
+
+@tool
+def delete_agenda_item(ctx: ElroyContext, item_name: str) -> str:
+    """Delete an agenda item permanently.
+
+    Args:
+        item_name (str): The file stem (name without .md) of the agenda item, or a substring of it.
+
+    Returns:
+        str: Confirmation message.
+    """
+    agenda_dir = get_agenda_dir()
+    matches = [p for p in agenda_dir.glob("*.md") if item_name.lower() in p.stem.lower()]
+    if not matches:
+        raise RecoverableToolError(f"No agenda item found matching '{item_name}'.")
+    if len(matches) > 1:
+        names = ", ".join(p.stem for p in matches)
+        raise RecoverableToolError(f"Multiple agenda items match '{item_name}': {names}. Be more specific.")
+    matches[0].unlink()
+    return f"Agenda item '{matches[0].stem}' deleted."
+
+
+@user_only_tool
+def list_agenda_items_cmd(ctx: ElroyContext, item_date: str | None = None) -> Table | str:
+    """List agenda items for a given date (defaults to today).
+
+    Args:
+        item_date (str | None): ISO 8601 date string (YYYY-MM-DD). Defaults to today.
+
+    Returns:
+        Table: A formatted table of agenda items.
+    """
+    if item_date:
+        try:
+            target_date = date.fromisoformat(item_date)
+        except ValueError as e:
+            raise RecoverableToolError(f"Invalid date format '{item_date}'. Use YYYY-MM-DD.") from e
+    else:
+        target_date = date.today()
+
+    agenda_dir = get_agenda_dir()
+    items = list_agenda_items(agenda_dir, for_date=target_date)
+
+    if not items:
+        return f"No agenda items for {target_date.isoformat()}."
+
+    table = Table(title=f"Agenda for {target_date.isoformat()}", show_lines=True)
+    table.add_column("Item", style="cyan")
+    table.add_column("Text", style="green")
+
+    for path, _fm, text in items:
+        table.add_row(path.stem, text)
+
+    return table
+
+
+def get_today_agenda_titles() -> list[str]:
+    """Return a list of today's incomplete agenda item names (for the UI panel)."""
+    agenda_dir = get_agenda_dir()
+    items = list_agenda_items(agenda_dir, for_date=date.today())
+    return [text.split("\n")[0] for _path, _fm, text in items]

--- a/elroy/repository/file_utils.py
+++ b/elroy/repository/file_utils.py
@@ -1,0 +1,55 @@
+"""Shared file-storage utilities for markdown files with YAML frontmatter."""
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
+
+
+def sanitize_filename(name: str, fallback: str = "item") -> str:
+    """Replace special chars with underscores, truncate to 80 chars."""
+    sanitized = re.sub(r"[^\w\s-]", "_", name)
+    sanitized = re.sub(r"\s+", "_", sanitized)
+    sanitized = sanitized.strip("_")
+    return sanitized[:80] or fallback
+
+
+def read_frontmatter(path: Path) -> dict[str, Any]:
+    """Parse YAML frontmatter from a markdown file. Returns {} if none."""
+    try:
+        content = path.read_text()
+    except OSError:
+        return {}
+    m = _FRONTMATTER_RE.match(content)
+    if not m:
+        return {}
+    try:
+        return yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def read_file_text(path: Path) -> str:
+    """Return the text content after frontmatter."""
+    content = path.read_text()
+    m = _FRONTMATTER_RE.match(content)
+    if m:
+        return content[m.end() :]
+    return content
+
+
+def update_frontmatter_fields(path: Path, updates: dict[str, Any]) -> None:
+    """Update fields in the YAML frontmatter of a markdown file."""
+    content = path.read_text()
+    m = _FRONTMATTER_RE.match(content)
+    body = content[m.end() :] if m else content
+    try:
+        fm: dict[str, Any] = yaml.safe_load(m.group(1)) or {} if m else {}
+    except yaml.YAMLError:
+        fm = {}
+    fm.update(updates)
+    frontmatter_str = yaml.dump(fm, default_flow_style=False).strip()
+    path.write_text(f"---\n{frontmatter_str}\n---\n\n{body.lstrip()}")

--- a/elroy/repository/memories/file_storage.py
+++ b/elroy/repository/memories/file_storage.py
@@ -1,32 +1,29 @@
 """File storage helpers for file-backed memories (Obsidian integration)."""
 
 import json
-import re
 from pathlib import Path
 from typing import Any
-
-import yaml
 
 from ...core.ctx import ElroyContext
 from ...core.logging import get_logger
 from ...db.db_models import Memory
+from ..file_utils import (
+    read_file_text,
+    read_frontmatter,
+    sanitize_filename,
+    update_frontmatter_fields,
+)
 
 logger = get_logger()
 
-_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
-
-
-def sanitize_filename(name: str) -> str:
-    """Replace special chars with underscores, truncate to 80 chars."""
-    sanitized = re.sub(r"[^\w\s-]", "_", name)
-    sanitized = re.sub(r"\s+", "_", sanitized)
-    sanitized = sanitized.strip("_")
-    return sanitized[:80] or "memory"
+# Aliases kept for callers that import these names directly
+read_memory_frontmatter = read_frontmatter
+read_memory_text = read_file_text
 
 
 def get_memory_file_path(memory_dir: Path, name: str, existing_paths: set[str]) -> Path:
     """Return a unique path for a new memory file in memory_dir."""
-    base = sanitize_filename(name)
+    base = sanitize_filename(name, fallback="memory")
     candidate = memory_dir / f"{base}.md"
     if str(candidate) not in existing_paths:
         return candidate
@@ -52,30 +49,6 @@ def write_memory_file(memory_dir: Path, memory: Memory, text: str, existing_path
     return path
 
 
-def read_memory_frontmatter(path: Path) -> dict[str, Any]:
-    """Parse YAML frontmatter from a markdown file. Returns {} if none."""
-    try:
-        content = path.read_text()
-    except OSError:
-        return {}
-    m = _FRONTMATTER_RE.match(content)
-    if not m:
-        return {}
-    try:
-        return yaml.safe_load(m.group(1)) or {}
-    except yaml.YAMLError:
-        return {}
-
-
-def read_memory_text(path: Path) -> str:
-    """Return the text content after frontmatter."""
-    content = path.read_text()
-    m = _FRONTMATTER_RE.match(content)
-    if m:
-        return content[m.end() :]
-    return content
-
-
 def archive_memory_file(file_path: Path, archive_dir: Path) -> Path:
     """Move a memory file to the archive directory. Returns the destination path."""
     archive_dir.mkdir(parents=True, exist_ok=True)
@@ -93,16 +66,7 @@ def archive_memory_file(file_path: Path, archive_dir: Path) -> Path:
 
 def write_id_to_frontmatter(path: Path, memory_id: int) -> None:
     """Write/update the id field in the frontmatter of a markdown file."""
-    content = path.read_text()
-    m = _FRONTMATTER_RE.match(content)
-    body = content[m.end() :] if m else content
-    try:
-        fm: dict[str, Any] = yaml.safe_load(m.group(1)) or {} if m else {}
-    except yaml.YAMLError:
-        fm = {}
-    fm["id"] = memory_id
-    frontmatter_str = yaml.dump(fm, default_flow_style=False).strip()
-    path.write_text(f"---\n{frontmatter_str}\n---\n\n{body.lstrip()}")
+    update_frontmatter_fields(path, {"id": memory_id})
 
 
 def _is_document_sourced(memory: Memory) -> bool:

--- a/elroy/tools/tools_and_commands.py
+++ b/elroy/tools/tools_and_commands.py
@@ -24,6 +24,12 @@ from ..repository.context_messages.tools import (
     add_memory_to_current_context,
     drop_memory_from_current_context,
 )
+from ..repository.agenda.tools import (
+    add_agenda_item,
+    complete_agenda_item,
+    delete_agenda_item,
+    list_agenda_items_cmd,
+)
 from ..repository.documents.tools import (
     get_document_excerpt,
     get_source_doc_metadata,
@@ -81,7 +87,12 @@ ALL_ACTIVE_REMINDER_COMMANDS: set[Callable] = {
     rename_reminder,
     update_reminder_text,
 }
+ALL_ACTIVE_AGENDA_COMMANDS: set[Callable] = {
+    complete_agenda_item,
+    delete_agenda_item,
+}
 NON_ARG_PREFILL_COMMANDS: set[Callable] = {
+    add_agenda_item,
     get_source_content_for_memory,
     create_reminder,
     create_memory,
@@ -115,6 +126,7 @@ USER_ONLY_COMMANDS = {
     search_memories,
     print_active_reminders,
     print_inactive_reminders,
+    list_agenda_items_cmd,
     set_assistant_name,
 }
 ASSISTANT_VISIBLE_COMMANDS: set[Callable] = {
@@ -125,6 +137,7 @@ ASSISTANT_VISIBLE_COMMANDS: set[Callable] = {
         | NON_CONTEXT_MEMORY_COMMANDS
         | ALL_ACTIVE_MEMORY_COMMANDS
         | ALL_ACTIVE_REMINDER_COMMANDS
+        | ALL_ACTIVE_AGENDA_COMMANDS
     )
     if getattr(f, IS_ENABLED, True)
 }


### PR DESCRIPTION
Implements a file-backed agenda item system following the existing
memories/reminders patterns. Agenda items are stored as markdown files
with YAML frontmatter and can be added, completed, deleted, and listed.

- Add `elroy/repository/agenda/` with file_storage and tools modules
- Add `get_agenda_dir()` to `elroy/config/paths.py`
- Register agenda tools in `tools_and_commands.py` for LLM and user use

https://claude.ai/code/session_01CDuJN8yZxywLkJXXkTJeVg

Add agenda items to slash-command autocomplete

Import ALL_ACTIVE_AGENDA_COMMANDS and today's agenda item titles in
_update_completions so complete_agenda_item and delete_agenda_item
suggestions appear in the input autocomplete list.

https://claude.ai/code/session_01CDuJN8yZxywLkJXXkTJeVg
