### PR TITLE
Update docs to reflect current TUI-based architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,32 +36,22 @@ For detailed installation instructions including Docker and source installation 
 
 ## Basic Usage
 
-Once installed locally you can:
+Once installed, run `elroy` to open the interactive chat interface:
+
 ```bash
-# Start the chat interface
-elroy chat
-
-# Or just 'elroy' which defaults to chat mode
 elroy
-
-# Process a single message and exit
-elroy message "Say hello world"
-
-# Force use of a specific tool
-elroy message "Create a reminder" --tool create_reminder
-
-# Elroy also accepts stdin
-echo "Say hello world" | elroy
 ```
+
+Elroy opens a terminal UI where you can chat, create memories, and manage reminders. Use `/help` inside the chat to see available slash commands.
 
 ## Memory and Reminder Tools
 ![Slash commands](images/slash_commands.gif)
 
-Elroy's tools allow it to create and manager memories and reminders. In the background, redundant memories are consolidated.
+Elroy's tools allow it to create and manage memories and reminders. In the background, redundant memories are consolidated.
 
 As reminders or memories become relevant to the conversation, they are recalled into context. A `Relevant Context` panel makes all information being surfaced to the assistant available to the user.
 
-All commands available to the assisstant are available to the user via `/` commands.
+All commands available to the assistant are also available to the user via `/` slash commands in the chat interface.
 
 For a guide of what tools are available and what they do, see: [tools guide](docs/tools_guide.md).
 
@@ -69,60 +59,35 @@ For a full reference of tools and their schemas, see: [tools schema reference](d
 
 
 ### Configuration
-Elroy is designed to be highly customizable, including CLI appearance and memory consolidation parameters.
+Elroy is designed to be highly customizable, including appearance and memory consolidation parameters.
 
-For full configuration options, see [configuration documentation](docs/configuration.md).
+Configuration can be provided via environment variables (e.g. `ELROY_CHAT_MODEL=gpt-5`) or a config file at `~/.elroy/elroy.conf.yaml`.
+
+For full configuration options, see [configuration documentation](docs/configuration/index.md).
 
 
 ### Supported Models
 
-Elroy supports OpenAI, Anthropic, Google (Gemini), and any OpenAI-compatible API's.
+Elroy supports OpenAI, Anthropic, Google (Gemini), and any OpenAI-compatible API.
 
-Model aliases are available for quick selection:
-- `--sonnet`: Anthropic's Sonnet model
-- `--opus`: Anthropic's Opus model
-- `--4o`: OpenAI's GPT-4o model
-- `--4o-mini`: OpenAI's GPT-4o-mini model
-- `--o1`: OpenAI's o1 model
-- `--o1-mini`: OpenAI's o1-mini model
+The model is selected automatically based on which API key is set, or can be configured explicitly:
 
-
-### Scripting Elroy
-
-![Remember command](images/remember_command.gif)
-
-You can script with elroy, using both the CLI package and the Python interface.
-
-#### Python scripts
-Elroy's API interface accepts the same parameters as the CLI. Scripting can be as simple as:
-
-
-```python
-ai = Elroy()
-
-# some other task
-ai.remember("This is how the task went")
-
-
-# Elroy will automatically reference memory against incoming messages
-ai.message("Here are memory augmented instructions")
-```
-
-To see a working example using, see [release_patch.py](scripts/release_patch.py)
-
-#### Shell scripting
-
-The chat interface accepts input from stdin, so you can pipe text to Elroy:
 ```bash
-# Process a single question
-echo "What is 2+2?" | elroy chat
+# Use an Anthropic model
+ELROY_CHAT_MODEL=claude-sonnet-4-5-20250929 elroy
 
-# Create a memory from file content
-cat meeting_notes.txt | elroy remember
+# Use a specific OpenAI model
+ELROY_CHAT_MODEL=gpt-5 elroy
 
-# Use a specific tool with piped input
-echo "Buy groceries" | elroy message --tool create_reminder
+# Use Gemini
+ELROY_CHAT_MODEL=gemini/gemini-2.0-flash elroy
 ```
+
+Common model aliases can be used as the `chat_model` config value:
+- `sonnet`: Anthropic's Claude 4.5 Sonnet
+- `opus`: Anthropic's Claude 4.5 Opus
+- `haiku`: Anthropic's Claude 3.5 Haiku
+- `o1`: OpenAI's o1 model
 
 ## Claude Code Integration
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,26 +1,19 @@
 # CLI
 
-Elroy provides a powerful command-line interface that makes it easy to interact with the AI assistant directly from your terminal.
+Elroy provides a terminal UI (TUI) for interacting with the AI assistant directly from your terminal.
 
-## Basic Usage
+## Starting Elroy
 
 ```bash
-# Start the chat interface
-elroy chat
-
-# Or just 'elroy' which defaults to chat mode
+# Open the interactive chat interface
 elroy
-
-# Process a single message and exit
-elroy message "Say hello world"
-
-# Create a memory
-elroy remember "This is important information I want to save"
 ```
+
+This opens a full-screen terminal application where you can chat with the assistant, create memories, and manage reminders.
 
 ## Slash Commands
 
-Elroy supports powerful slash commands for quick actions:
+Inside the chat interface, Elroy supports slash commands for quick actions:
 
 <div align="center">
   <img src="../images/slash_commands.gif" alt="Slash Commands demonstration" style="max-width: 100%; margin: 20px 0;">
@@ -33,62 +26,49 @@ Elroy supports powerful slash commands for quick actions:
 # Create a reminder
 /create_reminder Learn how to use Elroy effectively
 
+# List memories
+/print_memories
+
+# Search memories
+/search_memories project notes
+
+# Show configuration
+/print_config
+
+# See all available commands
+/help
 ```
 
 For a full list of available tools and slash commands, see the [Tools Guide](tools_guide.md).
 
-## Command Reference
+## Keyboard Shortcuts
 
-| Command | Description |
-|---------|-------------|
-| `elroy chat` | Opens an interactive chat session (default command) |
-| `elroy message TEXT` | Process a single message and exit. Use `--plain` for plaintext output instead of rich text |
-| `elroy remember [TEXT]` | Create a new memory from text or interactively |
-| `elroy ingest PATH` | Ingests document(s) at the given path into memory. Can process single files or directories |
-| `elroy list-models` | Lists supported chat models and exits |
-| `elroy list-tools` | Lists all available tools |
-| `elroy print-config` | Shows current configuration and exits |
-| `elroy version` | Show version and exit |
-| `elroy print-tool-schemas` | Prints the schema for a tool and exits |
-| `elroy set-persona TEXT` | Set a custom persona for the assistant |
-| `elroy reset-persona` | Removes any custom persona, reverting to the default |
-| `elroy show-persona` | Print the system persona and exit |
+| Key | Action |
+|-----|--------|
+| `Ctrl+D` | Exit |
+| `Ctrl+C` | Cancel current response |
+| `F2` | Toggle memory panel |
+
+## Configuration
+
+Elroy is configured via environment variables or a config file — there are no command-line flags. See the [Configuration Guide](configuration/index.md) for details.
+
+```bash
+# Use a specific model
+ELROY_CHAT_MODEL=claude-sonnet-4-5-20250929 elroy
+
+# Use a custom config file
+ELROY_CONFIG_PATH=~/my-elroy-config.yaml elroy
+```
 
 ## Document Ingestion
 
-Elroy supports ingesting documents to make their content available for memory and retrieval:
+To ingest documents into Elroy's memory, use the `/ingest_doc` slash command inside the chat interface, or configure background ingestion via the config file:
 
-```bash
-# Ingest a single file
-elroy ingest document.md
-
-# Ingest all files in a directory
-elroy ingest ./documents/
-
-# Ingest recursively with pattern matching
-elroy ingest ./documents/ --recursive --include "*.md,*.txt" --exclude "*.log"
-```
-
-### Ingest Command Options
-
-| Option | Description |
-|--------|-------------|
-| `--force-refresh, -f` | If true, any existing ingested documents will be discarded and re-ingested |
-| `--recursive, -r` | If path is a directory, recursively ingest all documents within it |
-| `--include, -i` | Glob pattern for files to include (e.g., '*.txt,*.md'). Multiple patterns can be comma-separated |
-| `--exclude, -e` | Glob pattern for files to exclude (e.g., '*.log'). Can also be used to exclude directories |
-
-## Shell Integration
-
-Elroy can be used in scripts and automated workflows:
-
-```bash
-# Process a single question
-echo "What is 2+2?" | elroy chat
-
-# Create a memory from file content
-cat meeting_notes.txt | elroy remember
-
-# Use a specific tool with piped input
-echo "Buy groceries" | elroy message --tool create_reminder
+```yaml
+# ~/.elroy/elroy.conf.yaml
+background_ingest_enabled: true
+background_ingest_paths:
+  - ~/documents/
+background_ingest_interval_minutes: 60
 ```

--- a/docs/configuration/basic.md
+++ b/docs/configuration/basic.md
@@ -1,39 +1,28 @@
 # Basic Configuration
 
-These settings control the core behavior of Elroy.
+These settings control the core behavior of Elroy. All options can be set via environment variables (e.g. `ELROY_DEBUG=true`) or in the config file at `~/.elroy/elroy.conf.yaml`.
 
 ## Options
 
-* `--config TEXT`: YAML config file path. Values override defaults but are overridden by CLI flags and environment variables. [default: ~/.config/elroy/config.yaml]
-* `--default-assistant-name TEXT`: Default name for the assistant. [default: Elroy]
-* `--debug / --no-debug`: Enable fail-fast error handling and verbose logging output. [default: false]
-* `--user-token TEXT`: User token to use for Elroy. [default: DEFAULT]
-* `--custom-tools-path TEXT`: Path to custom functions to load (can be specified multiple times)
-* `--max-ingested-doc-lines INTEGER`: Maximum number of lines to ingest from a document. If a document has more lines, it will be ignored.
-* `--database-url TEXT`: Valid SQLite or Postgres URL for the database. If Postgres, the pgvector extension must be installed.
-* `--inline-tool-calls / --no-inline-tool-calls`: Whether to enable inline tool calls in the assistant (better for some open source models). [default: false]
-* `--reflect / --no-reflect`: If true, the assistant will reflect on memories it recalls. This will lead to slower but richer responses. If false, memories will be less processed when recalled into memory. [default: false]
+| Config Key | Env Variable | Default | Description |
+|---|---|---|---|
+| `config_path` | `ELROY_CONFIG_PATH` | `~/.elroy/elroy.conf.yaml` | YAML config file path |
+| `default_assistant_name` | `ELROY_DEFAULT_ASSISTANT_NAME` | `Elroy` | Default name for the assistant |
+| `debug` | `ELROY_DEBUG` | `false` | Enable fail-fast error handling and verbose logging output |
+| `user_token` | `ELROY_USER_TOKEN` | `DEFAULT` | User token to use for Elroy |
+| `custom_tools_path` | `ELROY_CUSTOM_TOOLS_PATH` | - | Path to custom functions to load |
+| `database_url` | `ELROY_DATABASE_URL` | SQLite at `~/.elroy/elroy.db` | Valid SQLite URL for the database |
+| `inline_tool_calls` | `ELROY_INLINE_TOOL_CALLS` | `false` | Whether to enable inline tool calls (better for some open source models) |
+| `reflect` | `ELROY_REFLECT` | `false` | If true, the assistant will reflect on memories it recalls. Slower but richer responses. |
+| `max_ingested_doc_lines` | `ELROY_MAX_INGESTED_DOC_LINES` | `1000` | Maximum number of lines to ingest from a document |
 
-## Shell Integration
+## Example Config File
 
-* `--install-completion`: Install completion for the current shell
-* `--show-completion`: Show completion for current shell
-* `--help`: Show help message and exit
-
-## CLI Commands
-
-- `elroy chat` - Opens an interactive chat session (default command)
-- `elroy message TEXT` - Process a single message and exit
-- `elroy remember [TEXT]` - Create a new memory from text or interactively
-- `elroy ingest PATH` - Ingests document(s) at the given path into memory
-- `elroy list-models` - Lists supported chat models and exits
-- `elroy list-tools` - Lists all available tools
-- `elroy print-config` - Shows current configuration and exits
-- `elroy version` - Show version and exit
-- `elroy print-tool-schemas` - Prints the schema for a tool and exits
-- `elroy set-persona TEXT` - Set a custom persona for the assistant
-- `elroy reset-persona` - Removes any custom persona, reverting to the default
-- `elroy show-persona` - Print the system persona and exit
-- `elroy mcp` - MCP server commands
-
-Note: Running just `elroy` without any command will default to `elroy chat`.
+```yaml
+# ~/.elroy/elroy.conf.yaml
+default_assistant_name: "Elroy"
+debug: false
+user_token: DEFAULT
+chat_model: claude-sonnet-4-5-20250929
+reflect: false
+```

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -4,28 +4,23 @@ Elroy offers flexible configuration options to customize its behavior to your ne
 
 ## Configuration Methods
 
-Elroy's configuration can be specified in three ways, in order of precedence:
+Elroy's configuration can be specified in two ways, in order of precedence:
 
-1. **Command Line Flags**: Highest priority, overrides all other settings
+1. **Environment Variables**: Highest priority. All environment variables are prefixed with `ELROY_` and use uppercase with underscores:
    ```bash
-   elroy --chat-model claude-sonnet-4-5-20250929
-   ```
-
-2. **Environment Variables**: Second priority, overridden by CLI flags. All environment variables are prefixed with `ELROY_` and use uppercase with underscores:
-   ```bash
-   export ELROY_CHAT_MODEL=gpt-4o
+   export ELROY_CHAT_MODEL=gpt-5
    export ELROY_DEBUG=1
    ```
 
-3. **Configuration File**: Lowest priority, overridden by both CLI flags and environment variables
+2. **Configuration File**: Lowest priority, overridden by environment variables
    ```yaml
-   # ~/.config/elroy/config.yaml
-   chat_model: gpt-4o
+   # ~/.elroy/elroy.conf.yaml
+   chat_model: gpt-5
    debug: true
    ```
 
-The configuration file location can be specified with the `--config` flag or defaults to `~/.config/elroy/config.yaml`.
+The configuration file location defaults to `~/.elroy/elroy.conf.yaml` and can be overridden with the `ELROY_CONFIG_PATH` environment variable.
 
 For default config values, see [defaults.yml](https://github.com/elroy-bot/elroy/blob/main/elroy/defaults.yml)
 
-> **Note:** All configuration options can be set via environment variables with the prefix `ELROY_` (e.g.,`ELROY_CHAT_MODEL=gpt-4o`). The environment variable name is created by converting the option name to uppercase and adding the `ELROY_` prefix.
+> **Note:** All configuration options can be set via environment variables with the prefix `ELROY_` (e.g., `ELROY_CHAT_MODEL=gpt-5`). The environment variable name is created by converting the option name to uppercase and adding the `ELROY_` prefix.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -8,32 +8,45 @@ Elroy will automatically select appropriate models based on available API keys:
 
 | API Key | Chat Model | Embedding Model |
 |---------|------------|----------------|
-| `ANTHROPIC_API_KEY` | Claude 4.5 Sonnet | text-embedding-3-small |
-| `OPENAI_API_KEY` | GPT-4o | text-embedding-3-small |
-| `GEMINI_API_KEY` | Gemini 2.0 Flash | text-embedding-3-small |
+| `ANTHROPIC_API_KEY` | Claude 4.5 Sonnet (`claude-sonnet-4-5-20250929`) | text-embedding-3-small |
+| `OPENAI_API_KEY` | GPT-5 (`gpt-5`) | text-embedding-3-small |
+| `GEMINI_API_KEY` | Gemini 2.0 Flash (`gemini/gemini-2.0-flash`) | text-embedding-3-small |
 
 ## Model Configuration Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--chat-model TEXT` | The model to use for chat completions | *Inferred from API keys* |
-| `--chat-model-api-base TEXT` | Base URL for OpenAI compatible chat model API | - |
-| `--chat-model-api-key TEXT` | API key for OpenAI compatible chat model API | - |
-| `--embedding-model TEXT` | The model to use for text embeddings | text-embedding-3-small |
-| `--embedding-model-size INTEGER` | The size of the embedding model | 1536 |
-| `--embedding-model-api-base TEXT` | Base URL for OpenAI compatible embedding model API | - |
-| `--embedding-model-api-key TEXT` | API key for OpenAI compatible embedding model API | - |
-| `--enable-caching / --no-enable-caching` | Whether to enable caching for the LLM | true |
+Set via environment variable or config file:
+
+| Config Key | Env Variable | Description | Default |
+|---|---|---|---|
+| `chat_model` | `ELROY_CHAT_MODEL` | The model to use for chat completions | *Inferred from API keys* |
+| `chat_model_api_base` | `ELROY_CHAT_MODEL_API_BASE` | Base URL for OpenAI compatible chat model API | - |
+| `chat_model_api_key` | `ELROY_CHAT_MODEL_API_KEY` | API key for OpenAI compatible chat model API | - |
+| `embedding_model` | `ELROY_EMBEDDING_MODEL` | The model to use for text embeddings | `text-embedding-3-small` |
+| `embedding_model_size` | `ELROY_EMBEDDING_MODEL_SIZE` | The size of the embedding model | `1536` |
+| `embedding_model_api_base` | `ELROY_EMBEDDING_MODEL_API_BASE` | Base URL for OpenAI compatible embedding model API | - |
+| `embedding_model_api_key` | `ELROY_EMBEDDING_MODEL_API_KEY` | API key for OpenAI compatible embedding model API | - |
+| `enable_caching` | `ELROY_ENABLE_CACHING` | Whether to enable caching for the LLM | `true` |
 
 ## Model Aliases
 
-Shortcuts for common models:
+The following aliases can be used as the value of `chat_model` (via `ELROY_CHAT_MODEL` or config file):
 
-| Alias | Description |
-|-------|-------------|
-| `--sonnet` | Use Anthropic's Claude 4.5 Sonnet model |
-| `--opus` | Use Anthropic's Claude 4.5 Opus model |
-| `--4o` | Use OpenAI's GPT-4o model |
-| `--4o-mini` | Use OpenAI's GPT-4o-mini model |
-| `--o1` | Use OpenAI's o1 model |
-| `--o1-mini` | Use OpenAI's o1-mini model |
+| Alias | Model |
+|-------|-------|
+| `sonnet` | Claude 4.5 Sonnet (`claude-sonnet-4-5-20250929`) |
+| `opus` | Claude 4.5 Opus (`claude-opus-4-5-20251101`) |
+| `haiku` | Claude 3.5 Haiku (`claude-3-5-haiku-20241022`) |
+| `o1` | OpenAI o1 (`openai/o1`) |
+
+Example:
+
+```bash
+ELROY_CHAT_MODEL=sonnet elroy
+```
+
+Or in config file:
+
+```yaml
+# ~/.elroy/elroy.conf.yaml
+chat_model: sonnet
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,17 +63,14 @@ Ensure your env has `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` or whatever model prov
 elroy
 
 # Run with a specific model
-elroy --chat-model "gemini/gemini-2.0-flash"
-
-# To see more detailed CLI options
-elroy --help
+ELROY_CHAT_MODEL=gemini/gemini-2.0-flash elroy
 ```
 
 ## Slash Commands
 
 ![Slash Commands](images/slash_commands.gif)
 
-Elroy's CLI supports slash commands for quick actions. Some examples (run `/help` to see the full list):
+Elroy's TUI supports slash commands for quick actions. Some examples (run `/help` to see the full list):
 
 ```bash
 # Create a memory
@@ -82,37 +79,20 @@ Elroy's CLI supports slash commands for quick actions. Some examples (run `/help
 # Create a reminder
 /create_reminder Learn how to use Elroy effectively
 
-# Process a single message and exit
-elroy message "Say hello world"
+# Search memories
+/search_memories project notes
 
-# Force use of a specific tool
-elroy message "Create a reminder" --tool create_reminder
-```
-
-## Scripting with Elroy
-
-Elroy can be used in scripts and automated workflows:
-
-```python
-from elroy import Elroy
-
-ai = Elroy()
-
-# Create a memory
-ai.remember("Important project context")
-
-# Process a message with memory augmentation
-response = ai.message("What should I do next on the project?")
-print(response)
+# Show configuration
+/print_config
 ```
 
 ## Supported Models
 
 Elroy works with:
 
-- **OpenAI**: GPT-4o, GPT-4o-mini, o1, o1-mini
-- **Anthropic**: Claude 3.5 Sonnet, Claude 3 Opus
-- **Google**: Gemini
+- **OpenAI**: GPT-5, GPT-5-mini, o1
+- **Anthropic**: Claude 4.5 Sonnet, Claude 4.5 Opus, Claude 3.5 Haiku
+- **Google**: Gemini 2.0 Flash
 - Any OpenAI-compatible API
 
 Under the hood, Elroy uses [LiteLLM](https://www.litellm.ai/) to interface with model providers.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,12 +2,11 @@
 
 ## Prerequisites
 
+- Python 3.12
 - Relevant API keys (for simplest setup, set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`)
-- Database, either:
-    - SQLite (sqlite-vec will be installed)
-    - PostgreSQL with pgvector extension
+- SQLite (included with Python; sqlite-vec will be installed automatically)
 
-By default, Elroy will use SQLite. To add a custom DB, you can provide your database url either via the `ELROY_DATABASE_URL`, the `database_url` config value, or via the `--database-url` startup flag.
+By default, Elroy uses SQLite. To use a custom database path, set `ELROY_DATABASE_URL` or the `database_url` config value.
 
 ## Option 1: Using Install Script (Recommended)
 
@@ -26,8 +25,7 @@ This install script is based on [Aider's installation script](https://aider.chat
 ## Option 2: Using UV Manually
 
 ### Prerequisites
-- Python 3.10 or higher
-- Database (SQLite or PostgreSQL with pgvector extension)
+- Python 3.12
 - Relevant API keys (for simplest setup, set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`)
 
 1. Install UV:
@@ -61,8 +59,6 @@ elroy
 ### Prerequisites
 - Docker and Docker Compose
 
-This option automatically sets up everything you need, including the required PostgreSQL database with pgvector extension.
-
 1. Download the docker-compose.yml:
 ```bash
 curl -O https://raw.githubusercontent.com/elroy-bot/elroy/main/docker-compose.yml
@@ -74,11 +70,8 @@ curl -O https://raw.githubusercontent.com/elroy-bot/elroy/main/docker-compose.ym
 docker compose build --no-cache
 docker compose run --rm elroy
 
-# Add parameters as needed, e.g. here to use Anthropic's Sonnet model
-docker compose run --rm elroy --sonnet
-
 # Pass through all environment variables from host
-docker compose run --rm -e elroy
+docker compose run --rm -e OPENAI_API_KEY -e ANTHROPIC_API_KEY elroy
 
 # Or pass specific environment variable patterns
 docker compose run --rm -e "ELROY_*" -e "OPENAI_*" -e "ANTHROPIC_*" elroy
@@ -89,10 +82,9 @@ The Docker image is publicly available at `ghcr.io/elroy-bot/elroy`.
 ## Option 4: Installing from Source
 
 ### Prerequisites
-- Python 3.10 or higher
+- Python 3.12
 - uv package manager (install with `curl -LsSf https://astral.sh/uv/install.sh | sh`)
 - Relevant API keys (for simplest setup, set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`)
-- PostgreSQL database with pgvector extension
 
 ```bash
 # Clone the repository
@@ -101,7 +93,7 @@ cd elroy
 
 # Create virtual environment and install dependencies
 uv venv
-source .venv/bin/activate  # On Unix/MacOS
+source .venv/bin/activate  # On Unix/macOS
 # or
 .venv\Scripts\activate  # On Windows
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -1,67 +1,37 @@
 # Scripting
 
-Elroy can be scripted and automated, making it a powerful tool for integrating AI capabilities into your workflows and applications.
+Elroy is primarily a terminal UI application. For automation and scripting use cases, configure Elroy via environment variables and use the background ingestion feature.
 
-## Python API
+## Configuration via Environment Variables
 
-Elroy provides a Python API that allows you to integrate it into your Python scripts and applications:
+All Elroy settings can be set through environment variables prefixed with `ELROY_`:
 
-```python
-from elroy import Elroy
+```bash
+# Set the model
+export ELROY_CHAT_MODEL=gpt-5
 
-ai = Elroy()
+# Set user token for separate memory namespaces in scripts
+export ELROY_USER_TOKEN=my_script_user
 
-# Create a memory
-ai.remember("Important project context")
-
-# Process a message with memory augmentation
-response = ai.message("What should I do next on the project?")
-print(response)
+# Launch elroy
+elroy
 ```
 
-## Example: Automating Release Notes
+## Background Document Ingestion
 
-Here's an example of using Elroy to automate the creation of release notes:
+For workflows that need Elroy to process documents automatically, use background ingestion:
 
-```python
-from elroy import Elroy
-
-def generate_release_notes(version, changes):
-    ai = Elroy()
-
-    # Provide context about the changes
-    ai.remember(f"Changes for version {version}: {changes}")
-
-    # Ask Elroy to generate release notes
-    prompt = f"Generate release notes for version {version} based on the changes I've shared."
-    release_notes = ai.message(prompt)
-
-    return release_notes
-
-# Usage
-changes = """
-- Fixed bug in memory consolidation
-- Added support for new models
-- Improved CLI interface
-"""
-
-notes = generate_release_notes("1.2.0", changes)
-print(notes)
+```yaml
+# ~/.elroy/elroy.conf.yaml
+background_ingest_enabled: true
+background_ingest_paths:
+  - ~/documents/
+  - ~/notes/
+background_ingest_interval_minutes: 60
 ```
 
 ## Shell Scripting
 
-The chat interface accepts input from stdin, so you can pipe text to Elroy:
-
-```bash
-# Process a single question
-echo "What is 2+2?" | elroy chat
-
-# Create a memory from file content
-cat meeting_notes.txt | elroy remember
-
-# Use a specific tool with piped input
-echo "Buy groceries" | elroy message --tool create_reminder
-```
+Elroy's terminal UI reads from stdin when it is not a TTY, allowing basic piped input. However, interactive scripting workflows are best handled via the slash commands inside the TUI.
 
 For more examples, see the [examples directory](https://github.com/elroy-bot/elroy/tree/main/examples) in the Elroy repository.


### PR DESCRIPTION
The CLI was replaced with a Textual TUI and the Python API was removed. Key changes:
- Remove all CLI subcommands (chat, message, remember, ingest, version, etc.)
- Remove Python API (from elroy import Elroy) - was deleted in codebase
- Remove PostgreSQL as supported backend - was removed from codebase
- Fix Python version requirement: 3.10+ → 3.12
- Fix config file default path: ~/.config/elroy/config.yaml → ~/.elroy/elroy.conf.yaml
- Fix config file env var: ELROY_CONFIG_FILE → ELROY_CONFIG_PATH
- Update model aliases: remove --4o/--4o-mini, add haiku; note these are env/config values not CLI flags
- Update OpenAI default model: GPT-4o → GPT-5 (matches infer_chat_model_name in code)
- Rewrite cli.md for TUI with slash commands
- Rewrite scripting.md for env var / config-based automation
- Update configuration docs to show env var and config file format

https://claude.ai/code/session_01XUBuQWVe8FWf2FEtmq3ezu