### PR TITLE
Improve status bar with granular operation visibility

### DIFF
--- a/elroy/core/status.py
+++ b/elroy/core/status.py
@@ -1,0 +1,26 @@
+"""Thread-safe registry for background task status messages."""
+
+import threading
+
+_lock = threading.Lock()
+_background_statuses: dict[str, str] = {}
+
+
+def set_background_status(key: str, message: str) -> None:
+    """Record that a background operation is running."""
+    with _lock:
+        _background_statuses[key] = message
+
+
+def clear_background_status(key: str) -> None:
+    """Clear a background operation status."""
+    with _lock:
+        _background_statuses.pop(key, None)
+
+
+def get_background_status() -> str | None:
+    """Return the first active background status message, or None."""
+    with _lock:
+        if _background_statuses:
+            return next(iter(_background_statuses.values()))
+        return None

--- a/elroy/io/textual_app.py
+++ b/elroy/io/textual_app.py
@@ -203,6 +203,8 @@ class ElroyApp(App):
         self._spinner_chars = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
         self._spinner_index = 0
         self._spinner_handle = None
+        self._status_message = "thinking..."
+        self._bg_status_handle = None
         self._load_input_history()
 
     # ── history ──────────────────────────────────────────────────────────────
@@ -247,6 +249,7 @@ class ElroyApp(App):
 
         self.title = get_assistant_name(self.ctx)
         self._stop_spinner()  # initialise status bar with model name
+        self._bg_status_handle = self.set_interval(1.0, self._tick_background_status)
         self._start_session()
 
     # ── memory panel ─────────────────────────────────────────────────────────
@@ -301,12 +304,18 @@ class ElroyApp(App):
 
     def _run_stream(self, stream: Iterator) -> None:
         """Consume a message stream (call from worker thread)."""
+        from ..llm.stream_parser import StatusUpdate
+
         self._streaming = True
         self.call_from_thread(self._set_input_disabled, True)
         self.call_from_thread(self._start_spinner)
         try:
             for item in stream:
-                self.io.print(item, end="")
+                if isinstance(item, StatusUpdate):
+                    self._status_message = item.content
+                    self.call_from_thread(self._update_spinner_text)
+                else:
+                    self.io.print(item, end="")
         finally:
             self.call_from_thread(self._flush_thought_buffer)
             self.call_from_thread(self._flush_streaming_buffer)
@@ -461,6 +470,7 @@ class ElroyApp(App):
 
     def _start_spinner(self) -> None:
         self._spinner_index = 0
+        self._status_message = "thinking..."
         if self._spinner_handle:
             self._spinner_handle.stop()
         self._spinner_handle = self.set_interval(0.08, self._tick_spinner)
@@ -470,17 +480,42 @@ class ElroyApp(App):
 
         self._spinner_index = (self._spinner_index + 1) % len(self._spinner_chars)
         with contextlib.suppress(Exception):
-            self.query_one("#status-bar", Label).update(f"{self._spinner_chars[self._spinner_index]} thinking...")
+            self.query_one("#status-bar", Label).update(f"{self._spinner_chars[self._spinner_index]} {self._status_message}")
+
+    def _update_spinner_text(self) -> None:
+        """Immediately refresh the status bar text without advancing the spinner frame."""
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            spinner_char = self._spinner_chars[self._spinner_index]
+            self.query_one("#status-bar", Label).update(f"{spinner_char} {self._status_message}")
 
     def _stop_spinner(self) -> None:
         if self._spinner_handle:
             self._spinner_handle.stop()
             self._spinner_handle = None
+        self._status_message = "thinking..."
+        self._update_idle_status()
+
+    def _update_idle_status(self) -> None:
+        """Refresh the status bar when not streaming, incorporating background task status."""
+        import contextlib
+
+        from ..core.status import get_background_status
+
         try:
             model_name = self.ctx.chat_model.name
-            self.query_one("#status-bar", Label).update(f"● {model_name}")
         except Exception:
-            pass
+            return
+        bg = get_background_status()
+        text = f"● {model_name}  ⟳ {bg}" if bg else f"● {model_name}"
+        with contextlib.suppress(Exception):
+            self.query_one("#status-bar", Label).update(text)
+
+    def _tick_background_status(self) -> None:
+        """Periodically update the idle status bar with background task activity."""
+        if not self._streaming:
+            self._update_idle_status()
 
 
 def make_app(**overrides) -> ElroyApp:

--- a/elroy/io/textual_io.py
+++ b/elroy/io/textual_io.py
@@ -24,9 +24,12 @@ class TextualIO(ElroyIO):
 
     def print(self, message, end: str = "\n") -> None:
         from ..core.logging import get_logger
-        from ..llm.stream_parser import AssistantInternalThought, AssistantResponse, AssistantToolResult
+        from ..llm.stream_parser import AssistantInternalThought, AssistantResponse, AssistantToolResult, StatusUpdate
 
         logger = get_logger()
+
+        if isinstance(message, StatusUpdate):
+            return  # handled by _run_stream directly; never written to chat history
 
         if isinstance(message, AssistantInternalThought):
             if not self.show_internal_thought:

--- a/elroy/llm/stream_parser.py
+++ b/elroy/llm/stream_parser.py
@@ -44,6 +44,12 @@ class SystemWarning(TextOutput):
     content: str
 
 
+class StatusUpdate(BaseModel):
+    """Transient status message for display in the status bar (never written to chat history)."""
+
+    content: str
+
+
 class CodeBlock(BaseModel):
     """Represents a code block that can be formatted with Rich"""
 

--- a/elroy/messenger/messenger.py
+++ b/elroy/messenger/messenger.py
@@ -11,7 +11,7 @@ from ..core.latency import LatencyTracker
 from ..core.logging import get_logger
 from ..core.tracing import tracer
 from ..db.db_models import FunctionCall
-from ..llm.stream_parser import AssistantInternalThought, AssistantResponse, CodeBlock
+from ..llm.stream_parser import AssistantInternalThought, AssistantResponse, CodeBlock, StatusUpdate
 from ..repository.context_messages.data_models import ContextMessage
 from ..repository.context_messages.operations import add_context_messages
 from ..repository.context_messages.queries import get_context_messages
@@ -43,6 +43,7 @@ def process_message(
     if force_tool and not enable_tools:
         logger.warning("force_tool set, but enable_tools is False. Ignoring force_tool.")
 
+    yield StatusUpdate(content="loading context...")
     with ctx.latency_tracker.measure("load_context_messages"):
         context_messages: list[ContextMessage] = pipe(
             get_context_messages(ctx),
@@ -61,6 +62,7 @@ def process_message(
 
     # Use classifier to determine if memory recall is necessary
     if ctx.memory_config.memory_recall_classifier_enabled:
+        yield StatusUpdate(content="classifying recall...")
         with ctx.latency_tracker.measure("memory_recall_classification"):
             recall_decision = should_recall_memory(
                 ctx=ctx,
@@ -70,6 +72,7 @@ def process_message(
 
         if recall_decision.needs_recall:
             logger.debug(f"Memory recall enabled: {recall_decision.reasoning}")
+            yield StatusUpdate(content="fetching memories...")
             with ctx.latency_tracker.measure("memory_recall", needs_recall=True):
                 new_msgs += get_relevant_memory_context_msgs(ctx, context_messages + new_msgs)
         else:
@@ -77,6 +80,7 @@ def process_message(
             ctx.latency_tracker.track("memory_recall", 0, skipped=True)
     else:
         # Classifier disabled, always do recall (backward compatibility)
+        yield StatusUpdate(content="fetching memories...")
         with ctx.latency_tracker.measure("memory_recall", classifier_disabled=True):
             new_msgs += get_relevant_memory_context_msgs(ctx, context_messages + new_msgs)
 
@@ -93,6 +97,7 @@ def process_message(
                 yield AssistantInternalThought(content=new_msg.content)
         yield AssistantInternalThought(content="\n\n")  # empty line to separate internal thoughts from assistant responses
 
+    yield StatusUpdate(content="thinking...")
     loops = 0
     while True:
         # new_msgs accumulates across all loops, so we can only store new messages once
@@ -118,6 +123,7 @@ def process_message(
                     # Note: there's some slightly weird behavior here if the tool call results in context messages being added.
                     # Since we're not persisting new context messages until the end of this loop, context messages from within
                     # tool call executions will show up before the user message it's responding to.
+                    yield StatusUpdate(content=f"running {stream_chunk.function_name}...")
                     with ctx.latency_tracker.measure("tool_execution", tool=stream_chunk.function_name):
                         tool_call_result = exec_function_call(ctx, stream_chunk)
                         tool_context_messages.append(
@@ -130,6 +136,7 @@ def process_message(
                         )
 
                         yield tool_call_result
+                    yield StatusUpdate(content="thinking...")
 
         new_msgs.append(
             ContextMessage(

--- a/elroy/repository/documents/background.py
+++ b/elroy/repository/documents/background.py
@@ -9,6 +9,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from ...core.async_tasks import get_scheduler, schedule_task
 from ...core.ctx import ElroyContext
 from ...core.logging import get_logger
+from ...core.status import clear_background_status, set_background_status
 from ...repository.user.operations import get_or_create_user_preference
 from ...utils.clock import utc_now
 from .operations import do_ingest, do_ingest_dir
@@ -28,6 +29,8 @@ def background_ingest_task(ctx: ElroyContext) -> None:
         return
 
     logger.info(f"Starting background ingestion for {len(paths)} paths")
+    status_key = f"ingest_{ctx.user_id}"
+    set_background_status(status_key, "ingesting documents...")
 
     # Record the start time
     start_time = utc_now()
@@ -77,6 +80,7 @@ def background_ingest_task(ctx: ElroyContext) -> None:
             logger.error(f"Background ingestion failed for {path}: {e}", exc_info=True)
 
     logger.info("Background ingestion completed")
+    clear_background_status(status_key)
 
     # Update the last run time in user preferences
     try:

--- a/elroy/repository/memories/background.py
+++ b/elroy/repository/memories/background.py
@@ -10,6 +10,7 @@ from sqlmodel import select
 from ...core.async_tasks import get_scheduler
 from ...core.ctx import ElroyContext
 from ...core.logging import get_logger
+from ...core.status import clear_background_status, set_background_status
 from ...db.db_models import Memory
 from .file_storage import (
     read_memory_frontmatter,
@@ -35,6 +36,9 @@ def sync_memory_files(ctx: ElroyContext) -> None:
     memory_dir = ctx.memory_dir_path
     if not memory_dir:
         return
+
+    status_key = f"memory_sync_{ctx.user_id}"
+    set_background_status(status_key, "syncing memories...")
 
     # Scan all .md files in memory_dir root (non-recursive, skip archive/)
     disk_files: list[Path] = [p for p in memory_dir.glob("*.md") if p.is_file()]
@@ -140,6 +144,8 @@ def sync_memory_files(ctx: ElroyContext) -> None:
                 mark_inactive(ctx, db_memory)
             except Exception as e:
                 logger.error(f"Failed to mark memory {db_memory.id} inactive: {e}", exc_info=True)
+
+    clear_background_status(status_key)
 
 
 def schedule_memory_file_sync(ctx: ElroyContext) -> Job | None:


### PR DESCRIPTION
During message processing, the status bar now shows specific phases
instead of a static "thinking...":
  - "loading context..."
  - "classifying recall..." (when classifier is enabled)
  - "fetching memories..."
  - "thinking..." (LLM completion)
  - "running <tool_name>..." (per tool call)

Background tasks now report their status in the idle status bar:
  - "⟳ ingesting documents..." during document ingestion
  - "⟳ syncing memories..." during memory file sync

Implementation:
- New StatusUpdate model in stream_parser.py (transient, not persisted to chat history)
- New elroy/core/status.py: thread-safe background status registry
- messenger.py yields StatusUpdate at each processing phase
- textual_app.py _run_stream intercepts StatusUpdate to update spinner text
- 1Hz background tick refreshes idle status bar with background task activity

https://claude.ai/code/session_01LARXumJXZ8djx5EKAGqoi4
